### PR TITLE
small fixes but I realize that this might not even be an active repo any longer

### DIFF
--- a/Atlas-Security.md
+++ b/Atlas-Security.md
@@ -33,7 +33,7 @@ define([], function () {
 
 In the example above, the `configLocal.userAuthenticationEnabled` setting is updated to **true** to enable security in [ATLAS](https://github.com/OHDSI/Atlas). The `configLocal.api` contains the name and URL to connect to our WebAPI instance. `configLocal.authProviders` is an array that enables the specification of 1 or more authentication providers. A full list of authentication providers is included in the ATLAS `/js/config/app.js` `appConfig.authProviders` section and the ones that are enabled in your environment should be included in the `configLocal.authProviders` list.
 
-For those that followed the [[Basic Security Configuration]], the settings above will work. For those using OAuth/AD, please use the relevant configuration for your setup.
+For those that followed the [Basic Security Configuration](Basic-Security-Configuration.md), the settings above will work. For those using OAuth/AD, please use the relevant configuration for your setup.
 
 ## Defining an Administrator
 You should now be able to load ATLAS and find that you can login to the environment using the authentication provider configured in the previous step.  However, you will have limited permissions.  The following query will list the current permissions that all users have in the database:

--- a/Home.md
+++ b/Home.md
@@ -6,7 +6,8 @@ The OHDSI WebAPI is a Java-based application that is designed to provide a set o
 
 The following diagram depicts the logical architecture for the role WebAPI plays in the OHDSI tools ecosystem:
 
-[[/images/WebAPI-Configuration.png|OHDSI WebAPI Logical Architecture Diagram]]
+![OHDSI WebAPI Logical Architecture Diagram](/images/WebAPI-Configuration.png)
+
 
 --------------
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -2,11 +2,14 @@
 
 The [Atlas & WebAPI Working Group](http://www.ohdsi.org/web/wiki/doku.php?id=projects:workgroups:atlas-webapi) hold scheduled calls to review progress, technical roadblocks and timelines around new features or on-going issues. This roadmap is a reflection of the working group's commitments for this year.
 
-## Atlas/WebAPI 2.8 - Performance Optimizations
+## Atlas/WebAPI 2.15 - new features and bug fixes
 
-The 2.8 release will focus on optimizing features and functions in the platform. There will also be an effort to fix any outstanding bugs from the 2.7 release.
+The 2.15 release focused on optimizing features and functions in the platform. There will also be an effort to fix any outstanding bugs from the 2.14 release.
 
-## Atlas/WebAPI 3.0 - CDM v6 Support
+## Atlas/WebAPI 3.0 - Java > 8.0 support and maturation overhaul
 
-The 3.0 release of Atlas/WebAPI will provide support for CDM v6.x and will be a large overhaul of the code base with an eye towards maturing the platform's core components with unit/integration tests. 
+The 3.0 release of Atlas/WebAPI will provide support for Java > 8.0 and will be a large overhaul of the code base with an eye towards maturing the platform's core components with unit/integration tests. 
 
+## Atlas/WebAPI 4.0 - Architecture refactoring / Strategus 
+
+Join our development calls to learn more.


### PR DESCRIPTION
Small fixes because some links were broken and the roadmap was stale. 

I realize that this might not even be an active repo any longer as maybe this is the primary place to edit documentation: https://github.com/OHDSI/WebAPI/wiki ?? It is where my Read-restricted configuration page is located

Note there is also documentation on the old ohdsi.org wiki that probably should be pointing to the correct current version of things after double checking that no info is lost:
https://www.ohdsi.org/web/wiki/doku.php?id=documentation:software:webapi:basic_security  